### PR TITLE
Pin to version bracket

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ six>=1.5.2
 PyYAML
 python-jenkins>=0.4.8
 pbr>=1.0.0,<2.0
-stevedore>=1.8.0
+stevedore>=1.8.0,<1.20.0


### PR DESCRIPTION
Installing would include downloading the latest version of stevedore,
which is now incompatible with the pbr requirement.